### PR TITLE
Use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ outputs:
   signedReleaseFile12:
     description: 'The 12th signed release APK or AAB file'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
Upgrades the action to use node16 so we get rid of the ugly "node 12 deprecated" errors.